### PR TITLE
Set placeholder version and filter released steps to tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,24 @@ workflows:
   version: 2.1
   pipeline:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /^v.*/
       - hold:
           type: approval
           requires:
             - test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish:
           requires:
             - hold
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/gradient_utils/__init__.py
+++ b/gradient_utils/__init__.py
@@ -7,7 +7,8 @@ from gradient_utils.multi_node import get_tf_config
 from gradient_utils.utils import get_mongo_conn_str, data_dir, worker_hosts, export_dir, job_name, model_dir, ps_hosts, \
     task_index
 
-__version__ = "0.1.2"
+# this is automatically set to the latest tagged version by CircleCI
+__version__ = "0.0.1"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
This makes it so the CircleCI substitute logic works, see: https://github.com/Paperspace/gradient-utils/blob/b579e80236038e3d4864376dff450e9f0d8ceec4/.circleci/config.yml#L28-L43

It also filters the release steps to `v*` tags