### PR TITLE
Dropping Python 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,6 @@ commands:
       - run: make dc-test
 
 jobs:
-  test-python35:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - test:
-          version: "3.5"
   test-python36:
     docker:
       - image: cimg/base:stable
@@ -61,15 +55,25 @@ workflows:
   version: 2.1
   pipeline:
     jobs:
-      - test-python35
-      - test-python36
-      - test-python37
-      - test-python38
-      - test-python39
+      - test-python36:
+        filters:
+          branches:
+            only: /^.*/
+      - test-python37:
+        filters:
+          branches:
+            only: /^.*/
+      - test-python38:
+          filters:
+            branches:
+              only: /^.*/
+      - test-python39:
+          filters:
+            branches:
+              only: /^.*/
       - hold:
           type: approval
           requires:
-            - test-python35
             - test-python36
             - test-python37
             - test-python38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,18 +57,26 @@ workflows:
     jobs:
       - test-python36:
         filters:
+          tags:
+            only: /^v.*/
           branches:
             only: /^.*/
       - test-python37:
         filters:
+          tags:
+            only: /^v.*/
           branches:
             only: /^.*/
       - test-python38:
           filters:
+            tags:
+              only: /^v.*/
             branches:
               only: /^.*/
       - test-python39:
           filters:
+            tags:
+              only: /^v.*/
             branches:
               only: /^.*/
       - hold:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gradient-utils"
-version = "0.3.1"
+version = "0.3.0"
 description = "This is an SDK for performing Machine Learning with Gradient."
 authors = ["Paperspace Co. <info@paperspace.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gradient-utils"
-version = "0.3.0"
+version = "0.3.1"
 description = "This is an SDK for performing Machine Learning with Gradient."
 authors = ["Paperspace Co. <info@paperspace.com>"]
 license = "MIT"
@@ -10,7 +10,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Python 3.5 isn't an [active release](https://www.python.org/downloads/) anymore. Removing Python 3.5 from CI. Poetry already enforced 3.6 and above.

I'm also fixing the CI to run tests on tags since it wasn't because CircleCI is oddly configured. It needs to be explicitly specified to run on tags to run.