### PR TITLE
Run the release script with the CI docker-compose file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,6 @@ commands:
       - run: make dc-test
 
 jobs:
-  test-python35:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - test:
-          version: "3.5"
   test-python36:
     docker:
       - image: cimg/base:stable
@@ -61,15 +55,25 @@ workflows:
   version: 2.1
   pipeline:
     jobs:
-      - test-python35
-      - test-python36
-      - test-python37
-      - test-python38
-      - test-python39
+      - test-python36:
+        filters:
+          branches:
+            only: /^.*/
+      - test-python37:
+        filters:
+          branches:
+            only: /^.*/
+      - test-python38:
+          filters:
+            branches:
+              only: /^.*/
+      - test-python39:
+          filters:
+            branches:
+              only: /^.*/
       - hold:
           type: approval
           requires:
-            - test-python35
             - test-python36
             - test-python37
             - test-python38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,18 +57,26 @@ workflows:
     jobs:
       - test-python36:
         filters:
+          tags:
+            only: /^v.*/
           branches:
             only: /^.*/
       - test-python37:
         filters:
+          tags:
+            only: /^v.*/
           branches:
             only: /^.*/
       - test-python38:
           filters:
+            tags:
+              only: /^v.*/
             branches:
               only: /^.*/
       - test-python39:
           filters:
+            tags:
+              only: /^v.*/
             branches:
               only: /^.*/
       - hold:

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ export PYTHONPATH:=$(SRC)
 clean-build-publish:
 	rm -rf dist
 	docker-compose -f docker-compose.ci.yml build utils
-	docker-compose run -e POETRY_PYPI_TOKEN_PYPI utils poetry build && poetry publish
+	docker-compose -f docker-compose.ci.yml run -e POETRY_PYPI_TOKEN_PYPI utils poetry build && poetry publish
 
 dc-setup:
 	docker-compose -f docker-compose.ci.yml up --remove-orphans -d pushgateway

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gradient-utils"
-version = "0.3.1"
+version = "0.3.0"
 description = "This is an SDK for performing Machine Learning with Gradient."
 authors = ["Paperspace Co. <info@paperspace.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gradient-utils"
-version = "0.3.0"
+version = "0.3.1"
 description = "This is an SDK for performing Machine Learning with Gradient."
 authors = ["Paperspace Co. <info@paperspace.com>"]
 license = "MIT"
@@ -10,7 +10,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Automated releases failed because it was using the development docker-compose file instead of the CI file.

The CI file doesn't volume in the files. Voluming doesn't work in the CircleCI environment.