### PR TITLE
feat(metrics): Add steps to the add_metrics method

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,12 @@ m_logger["some_metric_2"].set_to_current_time()
 m_logger.push_metrics()
 
 # Insert metrics with a single command
-add_metrics({
-  'loss': 0.25,
-  'accuracy': 0.99
-})
+add_metrics({"loss": 0.25, "accuracy": 0.99})
 
+# Insert metrics with a step value
+# Note: add_metrics should be called once for a step. 
+#       Multiple calls with the same step may result in loss of metrics.
+add_metrics({"loss": 0.25, "accuracy": 0.99}, step=0)
 ```
 
 # Contributing
@@ -236,5 +237,8 @@ docker-compose build utils
 
 # To run tests
 docker-compose -f docker-compose.ci.yml run utils poetry run pytest
+
+# To autoformat
+docker-compose run utils poetry run autopep8 --in-place --aggressive --aggressive --recursive .
 ```
 

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -58,10 +58,11 @@ def get_workload_id():
 
 def add_metrics(
         metrics,
+        step=None,
         timeout=30):
     metrics_logger = MetricsLogger()
 
-    metrics = [Metric(key, value) for key, value in metrics.items()]
+    metrics = [Metric(key, value, step) for key, value in metrics.items()]
     for metric in metrics:
         metrics_logger.add_gauge(metric.key)
         metrics_logger[metric.key].set(metric.value)
@@ -70,9 +71,10 @@ def add_metrics(
 
 
 class Metric:
-    def __init__(self, key, value):
+    def __init__(self, key, value, step=None):
         self.key = key
         self.value = value
+        self.step = step
 
     @property
     def key(self):
@@ -93,6 +95,16 @@ class Metric:
         if not isinstance(v, Number):
             raise ValueError('Value of a metric can only be a number')
         self._value = v
+
+    @property
+    def step(self):
+        return self._step
+
+    @step.setter
+    def step(self, v):
+        if v != None and (not isinstance(v, int) or v < 0):
+            raise ValueError('Step can only be an integer >= 0')
+        self._step = v
 
 
 class MetricsLogger:

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -60,9 +60,9 @@ def add_metrics(
         metrics,
         step=None,
         timeout=30):
-    metrics_logger = MetricsLogger()
+    metrics_logger = MetricsLogger(step=step)
 
-    metrics = [Metric(key, value, step=step) for key, value in metrics.items()]
+    metrics = [Metric(key, value) for key, value in metrics.items()]
     for metric in metrics:
         metrics_logger.add_gauge(metric.key)
         metrics_logger[metric.key].set(metric.value)
@@ -136,6 +136,7 @@ class MetricsLogger:
         self.push_gateway = push_gateway or get_metric_pushgateway()
 
         self._metrics = dict()
+        self._step = step
 
     def __getitem__(self, item):
         """
@@ -145,22 +146,22 @@ class MetricsLogger:
         """
         return self._metrics[item]
 
-    def add_gauge(self, name, step=None):
-        self._add_metric(Gauge, name, step=step)
+    def add_gauge(self, name):
+        self._add_metric(Gauge, name)
 
-    def add_counter(self, name, step=None):
-        self._add_metric(Counter, name, step=step)
+    def add_counter(self, name):
+        self._add_metric(Counter, name)
 
-    def add_summary(self, name, step=None):
-        self._add_metric(Summary, name, step=step)
+    def add_summary(self, name):
+        self._add_metric(Summary, name)
 
-    def add_histogram(self, name, step=None):
-        self._add_metric(Histogram, name, step=step)
+    def add_histogram(self, name):
+        self._add_metric(Histogram, name)
 
-    def add_info(self, name, step=None):
-        self._add_metric(Info, name, step=step)
+    def add_info(self, name):
+        self._add_metric(Info, name)
 
-    def _add_metric(self, cls, name, documentation="", step=""):
+    def _add_metric(self, cls, name, documentation=""):
         new_metric = cls(
             name,
             documentation=documentation,
@@ -169,8 +170,7 @@ class MetricsLogger:
                 get_workload_label(),
                 "pod",
                 "step"])
-        self._metrics[name] = new_metric.labels(self.id, HOSTNAME, step)
-        self.grouping_key['step'] = step
+        self._metrics[name] = new_metric.labels(self.id, HOSTNAME, self._step)
 
     def push_metrics(self, timeout=30):
         push_to_gateway(

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -5,7 +5,7 @@ import logging
 from prometheus_client import push_to_gateway, Gauge, CollectorRegistry, Counter, Summary, Histogram, Info
 
 PUSH_GATEWAY_ENV = 'PAPERSPACE_METRIC_PUSHGATEWAY'
-PUSH_GATEWAY_DEFAULT = 'http://prom-aggregation-gateway:80'
+PUSH_GATEWAY_DEFAULT = 'http://gradient-processing-prometheus-pushgateway:9091'
 WORKLOAD_TYPE_ENV = 'PAPERSPACE_METRIC_WORKLOAD_TYPE'
 WORKLOAD_TYPE_DEFAULT = 'experiment'
 WORKLOAD_ID_ENV = 'PAPERSPACE_METRIC_WORKLOAD_ID'

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -67,8 +67,7 @@ def add_metrics(
     metrics = [Metric(key, value) for key, value in metrics.items()]
     for metric in metrics:
         metrics_logger.add_gauge(metric.key)
-        logger.warning(metrics_logger[metric.key])
-        logger.warning(metric.value)
+        logger.debug("Setting metric key: %s, value: %s", metrics_logger[metric.key], metric.value)
         metrics_logger[metric.key].set(metric.value)
 
     metrics_logger.push_metrics(timeout)

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -102,7 +102,7 @@ class Metric:
 
     @step.setter
     def step(self, v):
-        if v != None and (not isinstance(v, int) or v < 0):
+        if v is not None and (not isinstance(v, int) or v < 0):
             raise ValueError('Step can only be an integer >= 0')
         self._step = v
 
@@ -121,7 +121,12 @@ class MetricsLogger:
         >>> m_logger.push_metrics()
     """
 
-    def __init__(self, workload_id=None, registry=None, push_gateway=None, step=None):
+    def __init__(
+            self,
+            workload_id=None,
+            registry=None,
+            push_gateway=None,
+            step=None):
         """
         :param str workload_id:
         :param CollectorRegistry registry:

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -58,7 +58,7 @@ def get_workload_id():
     return _get_experiment_id()
 
 
-def _add_metrics(
+def add_metrics(
         metrics,
         step=None,
         timeout=30):
@@ -170,7 +170,7 @@ class MetricsLogger:
     def add_info(self, name):
         self._add_metric(Info, name)
 
-    def add_metric(self, cls, name, documentation=""):
+    def _add_metric(self, cls, name, documentation=""):
         new_metric = cls(
             name,
             documentation=documentation,

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -1,5 +1,6 @@
 import os
 from numbers import Number
+import logging
 
 from prometheus_client import push_to_gateway, Gauge, CollectorRegistry, Counter, Summary, Histogram, Info
 
@@ -11,6 +12,7 @@ WORKLOAD_ID_ENV = 'PAPERSPACE_METRIC_WORKLOAD_ID'
 LEGACY_EXPERIMENT_ID_ENV = 'PAPERSPACE_EXPERIMENT_ID'
 HOSTNAME = os.getenv("HOSTNAME")
 
+logger = logging.getLogger(__name__)
 
 def get_metric_pushgateway():
     return os.getenv(PUSH_GATEWAY_ENV, PUSH_GATEWAY_DEFAULT)
@@ -65,8 +67,8 @@ def add_metrics(
     metrics = [Metric(key, value) for key, value in metrics.items()]
     for metric in metrics:
         metrics_logger.add_gauge(metric.key)
-        print(metrics_logger[metric.key])
-        print(metric.value)
+        logger.warning(metrics_logger[metric.key])
+        logger.warning(metric.value)
         metrics_logger[metric.key].set(metric.value)
 
     metrics_logger.push_metrics(timeout)

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -170,7 +170,7 @@ class MetricsLogger:
     def add_info(self, name):
         self._add_metric(Info, name)
 
-    def _add_metric(self, cls, name, documentation=""):
+    def add_metric(self, cls, name, documentation=""):
         new_metric = cls(
             name,
             documentation=documentation,

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -65,6 +65,8 @@ def add_metrics(
     metrics = [Metric(key, value) for key, value in metrics.items()]
     for metric in metrics:
         metrics_logger.add_gauge(metric.key)
+        print(metrics_logger[metric.key])
+        print(metric.value)
         metrics_logger[metric.key].set(metric.value)
 
     metrics_logger.push_metrics(timeout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gradient-utils"
-version = "0.3.0"
+version = "0.4.0"
 description = "This is an SDK for performing Machine Learning with Gradient."
 authors = ["Paperspace Co. <info@paperspace.com>"]
 license = "MIT"

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -59,16 +59,15 @@ def test_add_metrics_pushes_metrics():
         assert metrics[key] == float(
             gateway_metrics[key]['metrics'][0]['value'])
         assert 'GAUGE' == gateway_metrics[key]['type']
+        assert 'None' == gateway_metrics[key]['metrics'][0]['labels']['step']
 
     # Clean up
     delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
 
 def test_add_metrics_push_with_step():
-    metrics_logger_config = MetricsLogger()
+    metrics_logger_config = MetricsLogger(step=0)
     delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
 
-    print(requests.get(f'{LOCAL_PUSH_GATEWAY}/api/v1/metrics').json())
-    registry = CollectorRegistry()
     metrics = {
         'cat': 1,
         'dog': 2,
@@ -85,8 +84,54 @@ def test_add_metrics_push_with_step():
         assert metrics[key] == float(
             gateway_metrics[key]['metrics'][0]['value'])
         assert 'GAUGE' == gateway_metrics[key]['type']
-        assert 'None' == gateway_metrics[key]['metrics'][0]['labels']['step']
+        assert '0' == gateway_metrics[key]['metrics'][0]['labels']['step']
 
     # Clean up
     delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+
+def test_add_metrics_multiple_steps():
+    metrics_logger_config = MetricsLogger(step=0)
+    metrics_logger_config_1 = MetricsLogger(step=1)
+    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(metrics_logger_config_1.push_gateway, metrics_logger_config_1.id, grouping_key=metrics_logger_config_1.grouping_key)
+
+    metrics = {
+        'cat': 1,
+        'dog': 2,
+        'catdog': 1.2
+    }
+    add_metrics(metrics, step=0)
+    add_metrics(metrics, step=1)
+
+    # Get metrics
+    r = requests.get(f'{LOCAL_PUSH_GATEWAY}/api/v1/metrics')
+    gateway_metrics = r.json()['data']
+    gateway_metrics_dict = {
+        '0': {},
+        '1': {}
+    }
+    for inserted_metrics in gateway_metrics:
+        for key in metrics:
+            step = inserted_metrics[key]['metrics'][0]['labels']['step']
+            gateway_metrics_dict[step][key] = {}
+            gateway_metrics_dict[step][key]['step'] = inserted_metrics[key]['metrics'][0]['labels']['step']
+            gateway_metrics_dict[step][key]['value'] = inserted_metrics[key]['metrics'][0]['value']
+            gateway_metrics_dict[step][key]['type'] = inserted_metrics[key]['type']
+
+    # Step 0
+    for key in metrics:
+        assert metrics[key] == float(
+            gateway_metrics_dict['0'][key]['value'])
+        assert 'GAUGE' == gateway_metrics_dict['0'][key]['type']
+
+    # Step 1
+    for key in metrics:
+        assert metrics[key] == float(
+            gateway_metrics_dict['1'][key]['value'])
+        assert 'GAUGE' == gateway_metrics_dict['1'][key]['type']
+
+
+    # Clean up
+    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(metrics_logger_config_1.push_gateway, metrics_logger_config_1.id, grouping_key=metrics_logger_config_1.grouping_key)
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -11,7 +11,10 @@ LOCAL_PUSH_GATEWAY = os.getenv('PAPERSPACE_METRIC_PUSHGATEWAY')
 
 def test_add_metric_integration():
     m_logger = MetricsLogger()
-    delete_from_gateway(m_logger.push_gateway, m_logger.id, grouping_key=m_logger.grouping_key)
+    delete_from_gateway(
+        m_logger.push_gateway,
+        m_logger.id,
+        grouping_key=m_logger.grouping_key)
 
     m_logger.add_gauge("some_metric_1")
     m_logger.add_gauge("some_metric_2")
@@ -20,7 +23,8 @@ def test_add_metric_integration():
     m_logger.push_metrics()
 
     expected = {
-        "some_metric_1": '4'
+        "some_metric_1": '4',
+        "some_metric_2": '0'
     }
 
     # Get metrics
@@ -33,14 +37,20 @@ def test_add_metric_integration():
         assert 'GAUGE' == gateway_metrics[key]['type']
 
     # Clean up
-    delete_from_gateway(m_logger.push_gateway, m_logger.id, grouping_key=m_logger.grouping_key)
+    delete_from_gateway(
+        m_logger.push_gateway,
+        m_logger.id,
+        grouping_key=m_logger.grouping_key)
 
 
 def test_add_metrics_pushes_metrics():
     # Before tests, clear the push gateway
     # TODO: Run this before each
     metrics_logger_config = MetricsLogger()
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
 
     registry = CollectorRegistry()
     metrics = {
@@ -62,11 +72,18 @@ def test_add_metrics_pushes_metrics():
         assert 'None' == gateway_metrics[key]['metrics'][0]['labels']['step']
 
     # Clean up
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
+
 
 def test_add_metrics_push_with_step():
     metrics_logger_config = MetricsLogger(step=0)
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
 
     metrics = {
         'cat': 1,
@@ -87,13 +104,23 @@ def test_add_metrics_push_with_step():
         assert '0' == gateway_metrics[key]['metrics'][0]['labels']['step']
 
     # Clean up
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
+
 
 def test_add_metrics_multiple_steps():
     metrics_logger_config = MetricsLogger(step=0)
     metrics_logger_config_1 = MetricsLogger(step=1)
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
-    delete_from_gateway(metrics_logger_config_1.push_gateway, metrics_logger_config_1.id, grouping_key=metrics_logger_config_1.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config_1.push_gateway,
+        metrics_logger_config_1.id,
+        grouping_key=metrics_logger_config_1.grouping_key)
 
     metrics = {
         'cat': 1,
@@ -130,14 +157,23 @@ def test_add_metrics_multiple_steps():
             gateway_metrics_dict['1'][key]['value'])
         assert 'GAUGE' == gateway_metrics_dict['1'][key]['type']
 
-
     # Clean up
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
-    delete_from_gateway(metrics_logger_config_1.push_gateway, metrics_logger_config_1.id, grouping_key=metrics_logger_config_1.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config_1.push_gateway,
+        metrics_logger_config_1.id,
+        grouping_key=metrics_logger_config_1.grouping_key)
+
 
 def test_add_metrics_aggregrates_same_step():
     metrics_logger_config = MetricsLogger(step=0)
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
 
     metrics = {
         'cat': 1,
@@ -153,11 +189,18 @@ def test_add_metrics_aggregrates_same_step():
     assert 1 == len(r.json()['data'])
 
     # Clean up
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
+
 
 def test_add_metrics_keeps_last_step():
     metrics_logger_config = MetricsLogger(step=0)
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)
 
     add_metrics({
         'cat': 1,
@@ -182,5 +225,7 @@ def test_add_metrics_keeps_last_step():
     assert 'dog' not in r.json()['data'][0]
 
     # Clean up
-    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
-    
+    delete_from_gateway(
+        metrics_logger_config.push_gateway,
+        metrics_logger_config.id,
+        grouping_key=metrics_logger_config.grouping_key)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -2,16 +2,45 @@ import mock
 import pytest
 import requests
 import os
+from prometheus_client import delete_from_gateway
 
-from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, add_metrics
+from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, add_metrics, MetricsLogger
 
 LOCAL_PUSH_GATEWAY = os.getenv('PAPERSPACE_METRIC_PUSHGATEWAY')
+
+
+def test_add_metric_integration():
+    m_logger = MetricsLogger()
+    delete_from_gateway(m_logger.push_gateway, m_logger.id, grouping_key=m_logger.grouping_key)
+
+    m_logger.add_gauge("some_metric_1")
+    m_logger.add_gauge("some_metric_2")
+    m_logger["some_metric_1"].set(3)
+    m_logger["some_metric_1"].inc()
+    m_logger.push_metrics()
+
+    expected = {
+        "some_metric_1": '4'
+    }
+
+    # Get metrics
+    r = requests.get(f'{LOCAL_PUSH_GATEWAY}/api/v1/metrics')
+    gateway_metrics = r.json()['data'][0]
+    for key in expected:
+        # Each metric is returned in a dictionary so we need to get the singular key
+        # Assert value returned by gateway matches what we provided
+        assert expected[key] == gateway_metrics[key]['metrics'][0]['value']
+        assert 'GAUGE' == gateway_metrics[key]['type']
+
+    # Clean up
+    delete_from_gateway(m_logger.push_gateway, m_logger.id, grouping_key=m_logger.grouping_key)
 
 
 def test_add_metrics_pushes_metrics():
     # Before tests, clear the push gateway
     # TODO: Run this before each
-    requests.put(f'{LOCAL_PUSH_GATEWAY}/api/v1/admin/wipe')
+    metrics_logger_config = MetricsLogger()
+    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
 
     registry = CollectorRegistry()
     metrics = {
@@ -30,3 +59,34 @@ def test_add_metrics_pushes_metrics():
         assert metrics[key] == float(
             gateway_metrics[key]['metrics'][0]['value'])
         assert 'GAUGE' == gateway_metrics[key]['type']
+
+    # Clean up
+    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+
+def test_add_metrics_push_with_step():
+    metrics_logger_config = MetricsLogger()
+    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+
+    print(requests.get(f'{LOCAL_PUSH_GATEWAY}/api/v1/metrics').json())
+    registry = CollectorRegistry()
+    metrics = {
+        'cat': 1,
+        'dog': 2,
+        'catdog': 1.2
+    }
+    add_metrics(metrics, step=0)
+
+    # Get metrics
+    r = requests.get(f'{LOCAL_PUSH_GATEWAY}/api/v1/metrics')
+    gateway_metrics = r.json()['data'][0]
+    for key in metrics:
+        # Each metric is returned in a dictionary so we need to get the singular key
+        # Assert value returned by gateway matches what we provided
+        assert metrics[key] == float(
+            gateway_metrics[key]['metrics'][0]['value'])
+        assert 'GAUGE' == gateway_metrics[key]['type']
+        assert 'None' == gateway_metrics[key]['metrics'][0]['labels']['step']
+
+    # Clean up
+    delete_from_gateway(metrics_logger_config.push_gateway, metrics_logger_config.id, grouping_key=metrics_logger_config.grouping_key)
+

--- a/tests/unit/test_experiment_metrics_logger.py
+++ b/tests/unit/test_experiment_metrics_logger.py
@@ -13,7 +13,8 @@ def test_should_create_metrics_logger_instance_with_required_parameters(
 
     assert metrics_logger.id == "some_id"
     assert metrics_logger.grouping_key == {
-        'label_metrics_experiment_handle': 'some_id'}
+        'label_metrics_experiment_handle': 'some_id',
+        'step': None}
     assert metrics_logger.push_gateway == "some_gateway"
     assert isinstance(metrics_logger.registry, CollectorRegistry)
 
@@ -38,15 +39,13 @@ def test_should_create_metrics_logger_instance_with_all_parameters(
     get_metric_pushgateway_patched.assert_not_called()
 
 
-@mock.patch("gradient_utils.metrics.Gauge")
-def test_should_add_gauge_to_logger_instance(gauge_patched):
+def test_should_add_gauge_to_logger_instance():
     metrics_logger = MetricsLogger("some_id")
     metric_name = "some_gauge"
 
     metrics_logger.add_gauge(metric_name)
 
     assert metric_name in metrics_logger._metrics
-    assert metrics_logger._metrics[metric_name] == gauge_patched.return_value
 
 
 @mock.patch("gradient_utils.metrics.Gauge")
@@ -60,15 +59,13 @@ def test_should_update_gauge_value(gauge_patched):
     gauge_patched().labels("some_id", None).set.assert_called_once_with(2)
 
 
-@mock.patch("gradient_utils.metrics.Counter")
-def test_should_add_counter_to_logger_instance(counter_patched):
+def test_should_add_counter_to_logger_instance():
     metrics_logger = MetricsLogger("some_id")
     metric_name = "some_counter"
 
     metrics_logger.add_counter(metric_name)
 
     assert metric_name in metrics_logger._metrics
-    assert metrics_logger._metrics[metric_name] == counter_patched.return_value
 
 
 @mock.patch("gradient_utils.metrics.Counter")
@@ -82,15 +79,13 @@ def test_should_update_counter_value(counter_patched):
     counter_patched().labels("some_id", None).inc.assert_called_once_with(2)
 
 
-@mock.patch("gradient_utils.metrics.Summary")
-def test_should_add_summary_to_logger_instance(summary_patched):
+def test_should_add_summary_to_logger_instance():
     metrics_logger = MetricsLogger("some_id")
     metric_name = "some_summary"
 
     metrics_logger.add_summary(metric_name)
 
     assert metric_name in metrics_logger._metrics
-    assert metrics_logger._metrics[metric_name] == summary_patched.return_value
 
 
 @mock.patch("gradient_utils.metrics.Summary")
@@ -104,15 +99,13 @@ def test_should_update_summary_value(summary_patched):
     summary_patched().labels("some_id", None).observe.assert_called_once_with(2)
 
 
-@mock.patch("gradient_utils.metrics.Histogram")
-def test_should_add_histogram_to_logger_instance(histogram_patched):
+def test_should_add_histogram_to_logger_instance():
     metrics_logger = MetricsLogger("some_id")
     metric_name = "some_histogram"
 
     metrics_logger.add_histogram(metric_name)
 
     assert metric_name in metrics_logger._metrics
-    assert metrics_logger._metrics[metric_name] == histogram_patched.return_value
 
 
 @mock.patch("gradient_utils.metrics.Histogram")
@@ -126,15 +119,13 @@ def test_should_update_histogram_value(histogram_patched):
     histogram_patched().labels("some_id", None).observe.assert_called_once_with(2)
 
 
-@mock.patch("gradient_utils.metrics.Info")
-def test_should_add_info_to_logger_instance(info_patched):
+def test_should_add_info_to_logger_instance():
     metrics_logger = MetricsLogger("some_id")
     metric_name = "some_info"
 
     metrics_logger.add_info(metric_name)
 
     assert metric_name in metrics_logger._metrics
-    assert metrics_logger._metrics[metric_name] == info_patched.return_value
 
 
 @mock.patch("gradient_utils.metrics.Info")
@@ -162,6 +153,6 @@ def test_should_use_push_to_gateway_to_log_metrics(push_to_gateway_patched):
         gateway=get_metric_pushgateway(),
         job="some_id",
         registry=registry,
-        grouping_key={'label_metrics_experiment_handle': 'some_id'},
+        grouping_key={'label_metrics_experiment_handle': 'some_id', 'step': None},
         timeout=30,
     )

--- a/tests/unit/test_experiment_metrics_logger.py
+++ b/tests/unit/test_experiment_metrics_logger.py
@@ -153,6 +153,8 @@ def test_should_use_push_to_gateway_to_log_metrics(push_to_gateway_patched):
         gateway=get_metric_pushgateway(),
         job="some_id",
         registry=registry,
-        grouping_key={'label_metrics_experiment_handle': 'some_id', 'step': None},
+        grouping_key={
+            'label_metrics_experiment_handle': 'some_id',
+            'step': None},
         timeout=30,
     )

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,8 +1,7 @@
 import mock
 import pytest
 
-from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, Metric
-from gradient_utils.metrics import add_metrics as add_metrics
+from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, Metric, add_metrics
 
 
 def test_add_metrics_errors_with_nonstring_key():

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -5,7 +5,6 @@ from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, Me
 
 
 def test_add_metrics_errors_with_nonstring_key():
-    registry = CollectorRegistry()
     metrics = {
         23: 2
     }
@@ -17,7 +16,6 @@ def test_add_metrics_errors_with_nonstring_key():
 
 
 def test_add_metrics_errors_with_nonnumber_value():
-    registry = CollectorRegistry()
     metrics = {
         'catdog': '2'
     }
@@ -44,13 +42,13 @@ def test_metric_creates_object():
 
 def test_metric_invalid_key():
     with pytest.raises(ValueError) as e:
-        metric = Metric(100, 100)
+        Metric(100, 100)
     assert "Key of a metric can only be a string" in str(e.value)
 
 
 def test_metric_invalid_value():
     with pytest.raises(ValueError) as e:
-        metric = Metric('key', 'value')
+        Metric('key', 'value')
     assert "Value of a metric can only be a number" in str(e.value)
 
 
@@ -77,15 +75,15 @@ def test_metric_valid_step():
 
 def test_metric_invalid_step():
     with pytest.raises(ValueError) as e:
-        metric = Metric('key', 100, step='One')
+        Metric('key', 100, step='One')
     assert "Step can only be an integer >= 0" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        metric = Metric('key', 100, step=-1)
+        Metric('key', 100, step=-1)
     assert "Step can only be an integer >= 0" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        metric = Metric('key', 100, step=2.3)
+        Metric('key', 100, step=2.3)
     assert "Step can only be an integer >= 0" in str(e.value)
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -39,7 +39,7 @@ def test_metric_creates_object():
     metric = Metric('key', 100)
     assert 'key' == metric.key
     assert 100 == metric.value
-    assert None == metric.step
+    assert None is metric.step
 
 
 def test_metric_invalid_key():
@@ -87,6 +87,7 @@ def test_metric_invalid_step():
     with pytest.raises(ValueError) as e:
         metric = Metric('key', 100, step=2.3)
     assert "Step can only be an integer >= 0" in str(e.value)
+
 
 def test_metric_invalid_changing_step():
     metric = Metric('key', 100, step=1)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -2,7 +2,7 @@ import mock
 import pytest
 
 from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, Metric
-from gradient_utils.metrics import _add_metrics as add_metrics
+from gradient_utils.metrics import add_metrics as add_metrics
 
 
 def test_add_metrics_errors_with_nonstring_key():

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -39,6 +39,7 @@ def test_metric_creates_object():
     metric = Metric('key', 100)
     assert 'key' == metric.key
     assert 100 == metric.value
+    assert None == metric.step
 
 
 def test_metric_invalid_key():
@@ -65,3 +66,30 @@ def test_metric_invalid_reassign_value():
     with pytest.raises(ValueError) as e:
         metric.value = 'value'
     assert "Value of a metric can only be a number" in str(e.value)
+
+
+def test_metric_valid_step():
+    metric = Metric('key', 100, step=1)
+    assert 1 == metric.step
+    metric.step = 0
+    assert 0 == metric.step
+
+
+def test_metric_invalid_step():
+    with pytest.raises(ValueError) as e:
+        metric = Metric('key', 100, step='One')
+    assert "Step can only be an integer >= 0" in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        metric = Metric('key', 100, step=-1)
+    assert "Step can only be an integer >= 0" in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        metric = Metric('key', 100, step=2.3)
+    assert "Step can only be an integer >= 0" in str(e.value)
+
+def test_metric_invalid_changing_step():
+    metric = Metric('key', 100, step=1)
+    with pytest.raises(ValueError) as e:
+        metric.step = 'One'
+    assert "Step can only be an integer >= 0" in str(e.value)


### PR DESCRIPTION
Overview:
This allows users to pass a step value when using `add_metrics`. The step will be attached as a label and surfaced through the API and Frontend.

Testing:
Started a notebook on prod, used the terminal to pull down this branch to build and install.
Pushed metrics with steps and it was registered by the pushgateway.
<img width="1038" alt="Screen Shot 2020-12-04 at 2 49 06 PM" src="https://user-images.githubusercontent.com/601386/101208376-1ac72e00-3640-11eb-849b-9fdd8a899417.png">
<img width="565" alt="Screen Shot 2020-12-04 at 2 50 05 PM" src="https://user-images.githubusercontent.com/601386/101208377-1b5fc480-3640-11eb-818c-208fa6a476d8.png">

