### PR TITLE
bug(metrics): Remove add_metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Usage example:
 
 ```python
 from gradient_utils import MetricsLogger
-from gradient_utils.metrics import add_metrics
+# Comment: add_metrics is not supported at the moment. Stay tuned!
+# from gradient_utils.metrics import add_metrics
 m_logger = MetricsLogger()
 m_logger.add_gauge("some_metric_1")
 m_logger["some_metric_1"].set(3)
@@ -217,10 +218,10 @@ m_logger["some_metric_2"].set_to_current_time()
 m_logger.push_metrics()
 
 # Insert metrics with a single command
-add_metrics({
-  'loss': 0.25,
-  'accuracy': 0.99
-})
+# add_metrics({
+#   'loss': 0.25,
+#   'accuracy': 0.99
+# })
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is an SDK for performing Machine Learning with Gradientº, it can be instal
 
 # Requirements
 
-This SDK requires Python 3.5+.
+This SDK requires Python 3.6+.
 
 To install it, run:
 

--- a/gradient_utils/__init__.py
+++ b/gradient_utils/__init__.py
@@ -2,7 +2,7 @@
 Gradient ML SDK
 """
 from gradient_utils.hyper_parameter import hyper_tune
-from gradient_utils.metrics import MetricsLogger, add_metrics
+from gradient_utils.metrics import MetricsLogger #, add_metrics
 from gradient_utils.multi_node import get_tf_config
 from gradient_utils.utils import get_mongo_conn_str, data_dir, worker_hosts, export_dir, job_name, model_dir, ps_hosts, \
     task_index

--- a/gradient_utils/__init__.py
+++ b/gradient_utils/__init__.py
@@ -23,5 +23,5 @@ __all__ = [
     "task_index",
     "hyper_tune",
     "MetricsLogger",
-    "add_metrics",
+    # "add_metrics",
 ]

--- a/gradient_utils/metrics.py
+++ b/gradient_utils/metrics.py
@@ -56,7 +56,7 @@ def get_workload_id():
     return _get_experiment_id()
 
 
-def add_metrics(
+def _add_metrics(
         metrics,
         timeout=30):
     metrics_logger = MetricsLogger()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gradient-utils"
-version = "0.3.0"
+version = "0.3.1"
 description = "This is an SDK for performing Machine Learning with Gradient."
 authors = ["Paperspace Co. <info@paperspace.com>"]
 license = "MIT"

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -3,7 +3,8 @@ import pytest
 import requests
 import os
 
-from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, add_metrics
+from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry
+from gradient_utils.metrics import _add_metrics as add_metrics
 
 LOCAL_PUSH_GATEWAY = os.getenv('PAPERSPACE_METRIC_PUSHGATEWAY')
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,7 +1,8 @@
 import mock
 import pytest
 
-from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, add_metrics, Metric
+from gradient_utils.metrics import get_metric_pushgateway, CollectorRegistry, Metric
+from gradient_utils.metrics import _add_metrics as add_metrics
 
 
 def test_add_metrics_errors_with_nonstring_key():


### PR DESCRIPTION
The current implementation of add_metrics is not supported by the infrastructure we currently have. This PR moved add_metrics to a private function to be used in the future.

This also bumps the version to 0.3.1.