### PR TITLE
infra(tests): Add CircleCI tests for cross compatibility with Tensorflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ commands:
       - run: pip check
 
 jobs:
-  test-39-package-compatibility:
+  test-38-package-compatibility:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.8
     steps:
       - test-package-compatibility
   test-python36:
@@ -66,7 +66,7 @@ workflows:
   version: 2.1
   pipeline:
     jobs:
-      - test-39-package-compatibility:
+      - test-38-package-compatibility:
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,6 @@ commands:
       - run: make dc-setup
       - run: make dc-test
   test-package-compatibility:
-    docker:
-      - image: cimg/python:3.9.0
     steps:
       - checkout
       - run: pip install poetry
@@ -23,12 +21,11 @@ commands:
       - run: pip check
 
 jobs:
-  test-package-compatibility:
+  test-39-package-compatibility:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/python:3.9
     steps:
-      - test:
-          version: "3.6"
+      - test-package-compatibility
   test-python36:
     docker:
       - image: cimg/base:stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
   version: 2.1
   pipeline:
     jobs:
-      - test-package-compatibility:
+      - test-39-package-compatibility:
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,18 @@ commands:
           version: 19.03.13
       - run: sed -i 's/_version_/<<parameters.version>>/' Dockerfile.ci && mv Dockerfile.ci Dockerfile
       - run: make dc-setup
+      - run: docker-compose -f docker-compose.ci.yml run utils pip install gradient
+      - run: docker-compose -f docker-compose.ci.yml run utils pip install tensorflow
+      - run: docker-compose -f docker-compose.ci.yml run utils pip install gradient-sdk
       - run: make dc-test
 
 jobs:
+  test-package-compatibility:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - test:
+          version: "3.6"
   test-python36:
     docker:
       - image: cimg/base:stable
@@ -55,6 +64,12 @@ workflows:
   version: 2.1
   pipeline:
     jobs:
+      - test-package-compatibility:
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            only: /^.*/
       - test-python36:
         filters:
           tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ commands:
     steps:
       - checkout
       - run: pip install poetry
-      - run: poetry build && pip install dist/*.tar.gz && pip install tensorflow
+      - run: poetry build && pip install dist/*.tar.gz
+      - run: pip install tensorflow
       - run: pip check
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,15 @@ commands:
           version: 19.03.13
       - run: sed -i 's/_version_/<<parameters.version>>/' Dockerfile.ci && mv Dockerfile.ci Dockerfile
       - run: make dc-setup
-      - run: docker-compose -f docker-compose.ci.yml run utils pip install gradient
-      - run: docker-compose -f docker-compose.ci.yml run utils pip install tensorflow
-      - run: docker-compose -f docker-compose.ci.yml run utils pip install gradient-sdk
       - run: make dc-test
+  test-package-compatibility:
+    docker:
+      - image: cimg/python:3.9.0
+    steps:
+      - checkout
+      - run: pip install poetry
+      - run: poetry build && pip install dist/*.tar.gz && pip install tensorflow
+      - run: pip check
 
 jobs:
   test-package-compatibility:


### PR DESCRIPTION
Add an automated test for installing alongside Tensorflow. More packages can be added to this test.

It fails now, as it should. After https://github.com/Paperspace/gradient-utils/pull/34 is merged, it should pass.