### PR TITLE
fix(metrics): Push metrics with per-metric grouping key.

### DIFF
--- a/gradient_utils/metrics/metrics.py
+++ b/gradient_utils/metrics/metrics.py
@@ -6,18 +6,43 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _get_default_grouping_key(workload_id=None, step=None):
+    return {
+        get_workload_label(): workload_id or get_workload_id(),
+        'step': step,
+    }
+
+
 def add_metrics(
         metrics_map,
         step=None,
         timeout=30):
     metrics = [Metric(key, value) for key, value in metrics_map.items()]
-    metrics_logger = MetricsLogger(step=step, grouping_key={"hash": hash(frozenset(metrics_map.items()))})
+    default_grouping_key = _get_default_grouping_key(step=step)
     for metric in metrics:
-        metrics_logger.add_gauge(metric.key)
-        logger.debug("Setting metric key: %s, value: %s", metrics_logger[metric.key], metric.value)
-        metrics_logger[metric.key].set(metric.value)
-
-    metrics_logger.push_metrics(timeout)
+        registry = CollectorRegistry(auto_describe=True)
+        new_metric_raw = Gauge(
+            metric.key,
+            documentation="",
+            registry=registry,
+            labelnames=[
+                get_workload_label(),
+                "pod",
+                "step"])
+        new_metric = new_metric_raw.labels(get_workload_id(), HOSTNAME, step)
+        new_metric.set(metric.value)
+        new_grouping_key = {
+            "name": metric.key,
+        }
+        new_grouping_key.update(default_grouping_key)
+        logger.debug("Setting metric key: %s, value: %s", metric.key, metric.value)
+        push_to_gateway(
+            gateway=get_metric_pushgateway(),
+            job=get_workload_id(),
+            registry=registry,
+            grouping_key=new_grouping_key,
+            timeout=timeout,
+        )
 
 
 class Metric:
@@ -76,24 +101,19 @@ class MetricsLogger:
             workload_id=None,
             registry=None,
             push_gateway=None,
-            step=None,
-            grouping_key={}):
+            step=None):
         """
         :param str workload_id:
         :param CollectorRegistry registry:
         :param str push_gateway:
+        :param int step:
         """
         self.id = workload_id or get_workload_id()
-        self.registry = registry or CollectorRegistry(auto_describe=True)
-        self.grouping_key = grouping_key.copy()
-        self.grouping_key.update({
-            get_workload_label(): self.id,
-            'step': step
-        })
-        self.push_gateway = push_gateway or get_metric_pushgateway()
-
-        self._metrics = dict()
+        self._registry = registry or CollectorRegistry(auto_describe=True)
         self._step = step
+        self._grouping_key = _get_default_grouping_key(self.id, self._step)
+        self._push_gateway = push_gateway or get_metric_pushgateway()
+        self._metrics = dict()
 
     def __getitem__(self, item):
         """
@@ -102,6 +122,12 @@ class MetricsLogger:
         :rtype Gauge|Counter|Summary|Histogram|Info
         """
         return self._metrics[item]
+
+    def set_step(self, step):
+        self._step = step
+        self._grouping_key.update({
+            'step': step,
+        })
 
     def add_gauge(self, name):
         self._add_metric(Gauge, name)
@@ -122,7 +148,7 @@ class MetricsLogger:
         new_metric = cls(
             name,
             documentation=documentation,
-            registry=self.registry,
+            registry=self._registry,
             labelnames=[
                 get_workload_label(),
                 "pod",
@@ -131,9 +157,9 @@ class MetricsLogger:
 
     def push_metrics(self, timeout=30):
         push_to_gateway(
-            gateway=self.push_gateway,
+            gateway=self._push_gateway,
             job=self.id,
-            registry=self.registry,
-            grouping_key=self.grouping_key,
+            registry=self._registry,
+            grouping_key=self._grouping_key,
             timeout=timeout,
         )

--- a/tests/unit/test_experiment_metrics_logger.py
+++ b/tests/unit/test_experiment_metrics_logger.py
@@ -12,11 +12,11 @@ def test_should_create_metrics_logger_instance_with_required_parameters(
     metrics_logger = MetricsLogger()
 
     assert metrics_logger.id == "some_id"
-    assert metrics_logger.grouping_key == {
+    assert metrics_logger._grouping_key == {
         'label_metrics_experiment_handle': 'some_id',
         'step': None}
-    assert metrics_logger.push_gateway == "some_gateway"
-    assert isinstance(metrics_logger.registry, CollectorRegistry)
+    assert metrics_logger._push_gateway == "some_gateway"
+    assert isinstance(metrics_logger._registry, CollectorRegistry)
 
 
 @mock.patch("gradient_utils.metrics.metrics.get_metric_pushgateway")
@@ -33,8 +33,8 @@ def test_should_create_metrics_logger_instance_with_all_parameters(
     )
 
     assert metrics_logger.id == "some_id"
-    assert metrics_logger.push_gateway == push_gateway
-    assert metrics_logger.registry is registry
+    assert metrics_logger._push_gateway == push_gateway
+    assert metrics_logger._registry is registry
     get_workload_id_patched.assert_not_called()
     get_metric_pushgateway_patched.assert_not_called()
 


### PR DESCRIPTION
This PR updates the grouping key change in #43 to be per-metric. The result is that for each `{step, metric}` pair, only the latest value is held by the gateway.